### PR TITLE
Fix GetPakFilenames crash

### DIFF
--- a/src/blarghrad.cpp
+++ b/src/blarghrad.cpp
@@ -125,10 +125,13 @@ std::vector<std::string> GetPakFilenames(char* pszCurDir) {
     wildcardPaks += "*.pak";
 
     _finddata_t finddata;
-    int handle = _findfirst(wildcardPaks.c_str(), &finddata);
-    while (handle != -1) {
-        result.push_back(finddata.name);
-        handle = _findnext(handle, &finddata);
+    intptr_t handle = _findfirst(wildcardPaks.c_str(), &finddata);
+    if (handle != -1) {
+        do
+        {
+            result.push_back(finddata.name);
+        }
+        while (_findnext(handle, &finddata) == 0);
     }
     _findclose(handle);
     return result;


### PR DESCRIPTION
More inline with https://docs.microsoft.com/en-us/cpp/c-runtime-library/filename-search-functions?view=vs-2019#example

_findnext does not return a handle.